### PR TITLE
Add an rsync dropbox configuration for 'switch' data.

### DIFF
--- a/conf/rsyncd.conf.in
+++ b/conf/rsyncd.conf.in
@@ -19,3 +19,12 @@ port=7999
   transfer logging = no
   ignore errors = no
   ignore nonreadable = yes
+
+[switch]
+  comment = Switch Traffic Utilization
+  path = RSYNCDIR_SWITCH
+  list = yes
+  read only = yes
+  transfer logging = no
+  ignore errors = no
+  ignore nonreadable = yes

--- a/init/initialize.sh
+++ b/init/initialize.sh
@@ -39,12 +39,15 @@ fi
 # NOTE: This is overwriting a pre-existing rsyncd.conf from the slicebase.
 sed -e "s;RSYNCDIR_FATHOM;/var/spool/$SLICENAME/$RSYNCDIR_FATHOM;" \
     -e "s;RSYNCDIR_UTILIZATION;/var/spool/$SLICENAME/$RSYNCDIR_UTILIZATION;" \
+    -e "s;RSYNCDIR_SWITCH;/var/spool/$SLICENAME/$RSYNCDIR_SWITCH;" \
     $SLICEHOME/conf/rsyncd.conf.in > /etc/rsyncd.conf
 
 mkdir -p /var/spool/$SLICENAME/$RSYNCDIR_FATHOM
 mkdir -p /var/spool/$SLICENAME/$RSYNCDIR_UTILIZATION
+mkdir -p /var/spool/$SLICENAME/$RSYNCDIR_SWITCH
 
 chown -R $SLICENAME:slices /var/spool/$SLICENAME/$RSYNCDIR_FATHOM
 chown -R $SLICENAME:slices /var/spool/$SLICENAME/$RSYNCDIR_UTILIZATION
+chown -R $SLICENAME:slices /var/spool/$SLICENAME/$RSYNCDIR_SWITCH
 
 service rsyncd restart

--- a/init/prepare.sh
+++ b/init/prepare.sh
@@ -23,6 +23,7 @@ mkdir $BUILD_DIR/conf
 cat <<\EOF > $BUILD_DIR/conf/config.sh
 RSYNCDIR_FATHOM=fathom
 RSYNCDIR_UTILIZATION=utilization
+RSYNCDIR_SWITCH=switch
 EOF
 
 # Set up pipeline


### PR DESCRIPTION
This PR adds an additional rsync dropbox to the mlab_utility slice configuration.

This will be the output directory for the switch traffic utilization data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/utility-support/12)
<!-- Reviewable:end -->
