### PR TITLE
Start and stop collectd via slicectrl.

### DIFF
--- a/init/start.sh
+++ b/init/start.sh
@@ -16,6 +16,9 @@ for port in $TCP_PORT_LIST ; do
     start_ncat $port 
 done
 
+service collectd-setup start
+service collectd start
+
 # DISABLED until we have the resources to restart development on the prototype
 # of the "push" data collection pipeline apparatus (which is what this is)
 #echo "Starting pipeline:"

--- a/init/start.sh
+++ b/init/start.sh
@@ -16,7 +16,6 @@ for port in $TCP_PORT_LIST ; do
     start_ncat $port 
 done
 
-service collectd-setup start
 service collectd start
 
 # DISABLED until we have the resources to restart development on the prototype

--- a/init/stop.sh
+++ b/init/stop.sh
@@ -15,3 +15,5 @@ done
 
 echo "Stopping pipeline:"
 killall pipeline
+
+service collectd stop


### PR DESCRIPTION
As far as I can tell, the current mlab_utility slice does not start collectd automatically. This is an oversight.

This PR adds calls to `start` and `stop` collectd via the slicectrl `start.sh` and `stop.sh` scripts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/utility-support/14)
<!-- Reviewable:end -->
