### PR TITLE
Perform rsync configuration before yum update.

### DIFF
--- a/init/initialize.sh
+++ b/init/initialize.sh
@@ -5,37 +5,8 @@ source $SLICEHOME/conf/config.sh
 
 set -e
 HOSTNAME=`hostname`
-ENABLE_DONAR=
-if grep -q $HOSTNAME $SLICEHOME/conf/donar.txt ; then
-    ENABLE_DONAR="yes"
-fi
 
-PACKAGES="nmap collectd-mlab"
-
-# NOTE: update configuration specific to this node.
-if ! test -f $SLICEHOME/.yumdone ; then 
-    if test x"$ENABLE_DONAR" = x"yes" ; then
-        PACKAGES="${PACKAGES} pdns pdns-backend-pipe bind-utils"
-    fi
-
-    yum install -y $PACKAGES
-
-    # NOTE: if there was an error installing, 'set -e' would stop us.
-    # NOTE: so signal success.
-    touch $SLICEHOME/.yumdone
-fi
-yum update -y
-
-if test x"$ENABLE_DONAR" = x"yes" ; then
-    # setup pdns 
-    cp /etc/pdns/pdns.conf /etc/pdns/pdns.conf.bak
-    cp $SLICEHOME/conf/pdns.conf /etc/pdns/pdns.conf
-    cp $SLICEHOME/conf/donar.txt /etc/donar.txt
-    cp $SLICEHOME/resolve-by-mlabns.py /usr/sbin/
-    chkconfig pdns on
-    service pdns start
-fi
-
+# Perform rsync configuration first.
 # NOTE: This is overwriting a pre-existing rsyncd.conf from the slicebase.
 sed -e "s;RSYNCDIR_FATHOM;/var/spool/$SLICENAME/$RSYNCDIR_FATHOM;" \
     -e "s;RSYNCDIR_UTILIZATION;/var/spool/$SLICENAME/$RSYNCDIR_UTILIZATION;" \
@@ -51,3 +22,34 @@ chown -R $SLICENAME:slices /var/spool/$SLICENAME/$RSYNCDIR_UTILIZATION
 chown -R $SLICENAME:slices /var/spool/$SLICENAME/$RSYNCDIR_SWITCH
 
 service rsyncd restart
+
+ENABLE_DONAR=
+if grep -q $HOSTNAME $SLICEHOME/conf/donar.txt ; then
+    ENABLE_DONAR="yes"
+fi
+PACKAGES="nmap collectd-mlab"
+# NOTE: update configuration specific to this node.
+if ! test -f $SLICEHOME/.yumdone ; then
+    if test x"$ENABLE_DONAR" = x"yes" ; then
+        PACKAGES="${PACKAGES} pdns pdns-backend-pipe bind-utils"
+    fi
+
+    yum install -y $PACKAGES
+
+    # NOTE: if there was an error installing, 'set -e' would stop us.
+    # NOTE: so signal success.
+    touch $SLICEHOME/.yumdone
+fi
+
+# NOTE: Create DONAR config if appropriate.
+if test x"$ENABLE_DONAR" = x"yes" ; then
+    # setup pdns
+    cp /etc/pdns/pdns.conf /etc/pdns/pdns.conf.bak
+    cp $SLICEHOME/conf/pdns.conf /etc/pdns/pdns.conf
+    cp $SLICEHOME/conf/donar.txt /etc/donar.txt
+    cp $SLICEHOME/resolve-by-mlabns.py /usr/sbin/
+    chkconfig pdns on
+    service pdns start
+fi
+
+yum update -y


### PR DESCRIPTION
During the DISCO deployment, we found that some servers updated the mlab_utility and collectd packages correctly, but data collection was failing.

This turned out to be due to the order of operations in the slice package initialize.sh. Because `yum update` occurred before the reconfiguration of rsyncd, if the update failed (due to transient conditions), then the rsync config would not be created correctly.

This change performs the rsync config *first* and allows the `yum update` to proceed as is. If it fails, the update process should continue via `yum-cron` at a later time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/utility-support/19)
<!-- Reviewable:end -->
