### PR TITLE
Changes defunct, non-existent reference to mirror.measurementlab.net

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN linux32 yum -y update
 RUN linux32 yum install -y wget git svn binutils qt gcc make patch libgomp
 RUN linux32 yum install -y glibc-headers glibc-devel kernel-headers kernel-devel htop dkms
 RUN linux32 yum install -y rpm-builder rpm-build m4 python-devel openssl-devel vim sudo man
-RUN linux32 yum install -y http://mirror.measurementlab.net/fedora-epel/6/i386/python-gflags-1.4-3.el6.noarch.rpm
+RUN linux32 yum install -y https://storage.googleapis.com/utility-support-mlab-oti/python-gflags-1.4-3.el6.noarch.rpm
 
 RUN linux32 rpm -ivh http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm
 


### PR DESCRIPTION
The Dockerfile was trying to install an RPM from mirror.measurementlab.net, which has been turned off for some time now. I fired up the old VM, downloaded the RPM, created a new public bucket (utility-support-mlab-oti), uploaded the file to it, and changed the URL in this Dockerfile to point to the GCS bucket.